### PR TITLE
Enhance Lenovo landing visuals with imagery updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lenovo Corporate Solutions | E-commerce</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./styles.css?v=2">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar__wrapper container">
+      <span class="topbar__tagline">Potencia corporativa con respaldo Lenovo</span>
+      <nav class="topbar__links">
+        <a href="#servicios">Servicios Gestionados</a>
+        <a href="#soluciones">Soluciones</a>
+        <a href="#contacto">Contacto</a>
+      </nav>
+    </div>
+  </header>
+
+  <nav class="navbar">
+    <div class="navbar__inner container">
+      <div class="navbar__brand">
+        <span class="navbar__logo">LenovoEC</span>
+        <span class="navbar__subtitle">Corporate Commerce</span>
+      </div>
+      <ul class="navbar__menu">
+        <li><a href="#productos">Catálogo</a></li>
+        <li><a href="#isg">Lenovo ISG</a></li>
+        <li><a href="#idg">Lenovo IDG</a></li>
+        <li><a href="#recursos">Recursos</a></li>
+        <li><a href="#contacto" class="button button--primary">Solicitar demo</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero">
+      <div class="hero__content container">
+        <div class="hero__copy">
+          <h1>Soluciones Lenovo para empresas visionarias</h1>
+          <p>Integra la innovación de Lenovo Infrastructure Solutions Group (ISG) y Intelligent Devices Group (IDG) en una experiencia de compra digital unificada y pensada para equipos de TI corporativos.</p>
+          <div class="hero__actions">
+            <a href="#productos" class="button button--primary">Explorar catálogo</a>
+            <a href="#contacto" class="button button--ghost">Asesor corporativo</a>
+          </div>
+          <div class="hero__badges">
+            <span>✔️ Entregas priorizadas</span>
+            <span>✔️ Contratos marco</span>
+            <span>✔️ Soporte 24/7</span>
+          </div>
+        </div>
+        <div class="hero__visual">
+          <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80" alt="Equipo de TI corporativo trabajando con soluciones Lenovo" class="hero__image">
+          <div class="hero__card">
+            <h2>Configuraciones a la medida</h2>
+            <p>Define políticas de compra, catálogos privados y acuerdos de servicio con visibilidad en tiempo real.</p>
+            <ul>
+              <li>Gestión de licitaciones y cotizaciones simultáneas</li>
+              <li>Portal para clientes multi-sede con control de presupuestos</li>
+              <li>Integración con ERP y plataformas de procurement</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="brand-strip">
+      <div class="brand-strip__wrapper container">
+        <div class="brand-strip__label">Ecosistema Lenovo</div>
+        <div class="brand-strip__logos">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/4/42/Lenovo_logo_2015.svg" alt="Logo Lenovo">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/4/46/Intel_logo_%282020%2C_dark_blue%29.svg" alt="Intel Partner">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/2/21/Nvidia_logo.svg" alt="NVIDIA Alliance">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/5/51/Microsoft_logo.svg" alt="Microsoft Solutions">
+        </div>
+      </div>
+    </section>
+
+    <section id="servicios" class="services container">
+      <h2>Experiencia corporativa de punta a punta</h2>
+      <div class="services__grid">
+        <article class="service-card">
+          <h3>Marketplace privado</h3>
+          <p>Catálogo dinámico segmentado por unidad de negocio, reglas de aprobación y disponibilidad en tiempo real.</p>
+        </article>
+        <article class="service-card">
+          <h3>Financiamiento y contratos</h3>
+          <p>Ofertas de leasing, pago por uso y contratos marco Lenovo TruScale diseñados para grandes corporaciones.</p>
+        </article>
+        <article class="service-card">
+          <h3>Servicios gestionados</h3>
+          <p>Implementación, soporte proactivo y administración del ciclo de vida completo de tus activos Lenovo.</p>
+        </article>
+        <article class="service-card">
+          <h3>Analytics &amp; reporting</h3>
+          <p>Paneles de control con métricas de cumplimiento, presupuesto y sustentabilidad para decisiones estratégicas.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="productos" class="catalog">
+      <div class="container">
+        <div class="catalog__header">
+          <h2>Catálogo inteligente Lenovo</h2>
+          <p>Personaliza tu vista entre soluciones de infraestructura (ISG) y dispositivos inteligentes (IDG).</p>
+        </div>
+        <div class="catalog__filters">
+          <button class="filter-button is-active" data-filter="all">Todos</button>
+          <button class="filter-button" data-filter="ISG">Lenovo ISG</button>
+          <button class="filter-button" data-filter="IDG">Lenovo IDG</button>
+          <button class="filter-button" data-filter="Servicios">Servicios &amp; Soporte</button>
+        </div>
+        <div class="catalog__grid" id="catalog-grid"></div>
+      </div>
+    </section>
+
+    <section id="isg" class="segment segment--isg">
+      <div class="container segment__wrapper">
+        <div class="segment__content">
+          <h2>Infrastructure Solutions Group (ISG)</h2>
+          <p>Soluciones de centro de datos con desempeño superior para cargas críticas. Diseñadas para escalar con tus necesidades de virtualización, inteligencia artificial y edge computing.</p>
+          <ul>
+            <li>Servidores ThinkSystem y ThinkAgile listos para la nube híbrida.</li>
+            <li>Infraestructura hiperconvergente certificada para VMware, Nutanix y Microsoft.</li>
+            <li>Equipos validados para SAP HANA, bases de datos y analítica avanzada.</li>
+          </ul>
+          <a class="button button--light" href="#contacto">Habla con un especialista ISG</a>
+        </div>
+        <div class="segment__badge">
+          <span>ISG</span>
+          <p>Infraestructura segura</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="idg" class="segment segment--idg">
+      <div class="container segment__wrapper segment__wrapper--reverse">
+        <div class="segment__content">
+          <h2>Intelligent Devices Group (IDG)</h2>
+          <p>Dispositivos inteligentes, listos para el trabajo híbrido con administración centralizada y servicios gestionados.</p>
+          <ul>
+            <li>Laptops ThinkPad y workstations ThinkStation con certificaciones ISV.</li>
+            <li>Soluciones de colaboración ThinkSmart para salas de reunión y espacios híbridos.</li>
+            <li>Servicios de despliegue, protección de datos y renovación tecnológica.</li>
+          </ul>
+          <a class="button button--dark" href="#contacto">Optimiza tu parque IDG</a>
+        </div>
+        <div class="segment__badge">
+          <span>IDG</span>
+          <p>Productividad inteligente</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="soluciones" class="solutions container">
+      <h2>Arquitecturas recomendadas</h2>
+      <div class="solutions__grid">
+        <article class="solution-card">
+          <h3>Data Center Moderno</h3>
+          <p>Infraestructura hiperconvergente ThinkAgile MX con gestión unificada, backup automatizado y recuperación ante desastres.</p>
+          <ul>
+            <li>Implementación en 6 semanas</li>
+            <li>Escalabilidad lineal</li>
+            <li>Soporte Premier</li>
+          </ul>
+        </article>
+        <article class="solution-card">
+          <h3>Trabajo Híbrido Seguro</h3>
+          <p>Bundle de laptops ThinkPad X1, monitores ThinkVision y servicios de seguridad ThinkShield para corporaciones globales.</p>
+          <ul>
+            <li>Provisioning automatizado</li>
+            <li>Gestión de identidades y cifrado</li>
+            <li>Renovación programada</li>
+          </ul>
+        </article>
+        <article class="solution-card">
+          <h3>Edge AI Industrial</h3>
+          <p>Servidores Lenovo SE con GPUs NVIDIA y software de análisis en tiempo real para operaciones industriales distribuidas.</p>
+          <ul>
+            <li>Resiliencia en ambientes extremos</li>
+            <li>Orquestación centralizada</li>
+            <li>Integración con plataformas OT</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section id="recursos" class="resources">
+      <div class="container resources__wrapper">
+        <div class="resources__content">
+          <h2>Recursos estratégicos</h2>
+          <p>Accede a materiales exclusivos, casos de éxito y certificaciones para respaldar tus decisiones de compra.</p>
+          <div class="resources__list">
+            <a class="resource-pill" href="#">Guía ISG para CIOs</a>
+            <a class="resource-pill" href="#">Whitepaper Modern Workplace</a>
+            <a class="resource-pill" href="#">Catálogo de servicios TruScale</a>
+            <a class="resource-pill" href="#">Casos de éxito sector financiero</a>
+          </div>
+        </div>
+        <div class="resources__cta">
+          <h3>Suscríbete al boletín ejecutivo</h3>
+          <form class="newsletter-form" id="newsletter-form">
+            <label for="newsletter-email" class="sr-only">Correo electrónico</label>
+            <input id="newsletter-email" name="email" type="email" placeholder="tu@empresa.com" required>
+            <button type="submit" class="button button--primary">Suscribirme</button>
+          </form>
+          <p class="newsletter-feedback" id="newsletter-feedback"></p>
+        </div>
+      </div>
+    </section>
+
+    <section id="contacto" class="contact">
+      <div class="container contact__wrapper">
+        <div class="contact__info">
+          <h2>Conversemos sobre tu próximo proyecto Lenovo</h2>
+          <p>Completa el formulario y uno de nuestros especialistas certificados te contactará en menos de 24 horas.</p>
+          <div class="contact__highlights">
+            <span>✔️ Oficinas regionales y soporte onsite</span>
+            <span>✔️ Integraciones API y procurement electrónico</span>
+            <span>✔️ Acuerdos de nivel de servicio personalizados</span>
+          </div>
+        </div>
+        <form class="contact-form" id="contact-form">
+          <div class="form-field">
+            <label for="name">Nombre completo</label>
+            <input id="name" type="text" name="name" required>
+          </div>
+          <div class="form-field">
+            <label for="company">Empresa</label>
+            <input id="company" type="text" name="company" required>
+          </div>
+          <div class="form-field">
+            <label for="email">Correo corporativo</label>
+            <input id="email" type="email" name="email" required>
+          </div>
+          <div class="form-field">
+            <label for="segment">Interés principal</label>
+            <select id="segment" name="segment" required>
+              <option value="" disabled selected>Selecciona una opción</option>
+              <option value="ISG">Infraestructura (ISG)</option>
+              <option value="IDG">Dispositivos inteligentes (IDG)</option>
+              <option value="Servicios">Servicios gestionados</option>
+              <option value="Financiamiento">Financiamiento &amp; contratos</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="message">Requerimientos</label>
+            <textarea id="message" name="message" rows="4" required></textarea>
+          </div>
+          <button type="submit" class="button button--primary">Solicitar asesoría</button>
+          <p class="form-feedback" id="contact-feedback"></p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__wrapper">
+      <div class="footer__brand">
+        <span class="footer__logo">LenovoEC</span>
+        <p>Soluciones corporativas Lenovo para organizaciones que necesitan disponibilidad, seguridad y escalabilidad.</p>
+      </div>
+      <div class="footer__columns">
+        <div>
+          <h4>Segmentos</h4>
+          <ul>
+            <li><a href="#isg">Infraestructura (ISG)</a></li>
+            <li><a href="#idg">Dispositivos (IDG)</a></li>
+            <li><a href="#soluciones">Paquetes estratégicos</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Soporte</h4>
+          <ul>
+            <li><a href="#">Portal clientes</a></li>
+            <li><a href="#">Mesa de ayuda 24/7</a></li>
+            <li><a href="#">Centro de recursos</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Contacto</h4>
+          <ul>
+            <li><a href="mailto:corporativo@lenovoec.com">corporativo@lenovoec.com</a></li>
+            <li><a href="#contacto">Agenda una reunión</a></li>
+            <li><a href="#">Políticas de seguridad</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer__legal">
+      <div class="container footer__legal-wrapper">
+        <span>© 2024 LenovoEC. Todos los derechos reservados.</span>
+        <span>Partners Platinum Lenovo | Certificación ISO 27001</span>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,215 @@
+const products = [
+  {
+    name: 'ThinkSystem SR650 V3',
+    category: 'ISG',
+    description: 'Servidor en rack 2U optimizado para cargas mixtas y virtualización masiva.',
+    price: 'Desde $8,500',
+    tags: ['Intel Xeon', 'VMware Ready', 'HCI'],
+    image:
+      'https://images.unsplash.com/photo-1580894906472-8e891970d9b0?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Servidores Lenovo ThinkSystem en un centro de datos',
+  },
+  {
+    name: 'ThinkAgile HX Series',
+    category: 'ISG',
+    description: 'Plataforma hiperconvergente co-diseñada con Nutanix para nube híbrida.',
+    price: 'Desde $11,200',
+    tags: ['Hiperconvergencia', 'Escalabilidad', 'Nutanix'],
+    image:
+      'https://images.unsplash.com/photo-1580894906471-0c168de229ac?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Infraestructura hiperconvergente Lenovo ThinkAgile',
+  },
+  {
+    name: 'ThinkEdge SE450',
+    category: 'ISG',
+    description: 'Servidor compacto para edge AI con GPU NVIDIA y tolerancia industrial.',
+    price: 'Desde $6,900',
+    tags: ['Edge', 'IA', 'GPU'],
+    image:
+      'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Servidor compacto Lenovo ThinkEdge en ambiente industrial',
+  },
+  {
+    name: 'ThinkPad X1 Carbon Gen 11',
+    category: 'IDG',
+    description: 'Ultrabook premium con certificaciones Intel vPro y Lenovo ThinkShield.',
+    price: 'Desde $1,750',
+    tags: ['Trabajo híbrido', 'vPro', 'ThinkShield'],
+    image:
+      'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Laptop Lenovo ThinkPad X1 Carbon sobre un escritorio corporativo',
+  },
+  {
+    name: 'ThinkStation P16',
+    category: 'IDG',
+    description: 'Workstation certificada ISV para ingeniería, render y data science.',
+    price: 'Desde $4,200',
+    tags: ['ISV', 'NVIDIA RTX', 'AMD Threadripper'],
+    image:
+      'https://images.unsplash.com/photo-1517430816045-df4b7de11d1d?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Workstation Lenovo ThinkStation para diseño y render',
+  },
+  {
+    name: 'ThinkSmart Hub',
+    category: 'IDG',
+    description: 'Solución de colaboración todo-en-uno para salas de reunión híbridas.',
+    price: 'Desde $3,100',
+    tags: ['Collab', 'Microsoft Teams', 'Zoom'],
+    image:
+      'https://images.unsplash.com/photo-1524758870432-af57e54afa26?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Dispositivo de colaboración Lenovo ThinkSmart en sala de reuniones',
+  },
+  {
+    name: 'Lenovo TruScale IaaS',
+    category: 'Servicios',
+    description: 'Infraestructura bajo consumo con pago por uso y soporte gestionado.',
+    price: 'Modelo suscripción',
+    tags: ['As-a-Service', 'Opex', 'SLA'],
+    image:
+      'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Centro de datos gestionado con servicios Lenovo TruScale',
+  },
+  {
+    name: 'Premier Support Plus',
+    category: 'Servicios',
+    description: 'Atención prioritaria 24/7, monitoreo proactivo y protección avanzada.',
+    price: 'Planes personalizados',
+    tags: ['Soporte', 'Seguridad', 'Garantía'],
+    image:
+      'https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=800&q=80',
+    imageAlt: 'Especialista Lenovo brindando soporte remoto a un cliente empresarial',
+  },
+];
+
+const catalogGrid = document.getElementById('catalog-grid');
+const filterButtons = document.querySelectorAll('.filter-button');
+const newsletterForm = document.getElementById('newsletter-form');
+const newsletterFeedback = document.getElementById('newsletter-feedback');
+const contactForm = document.getElementById('contact-form');
+const contactFeedback = document.getElementById('contact-feedback');
+
+function createProductCard(product) {
+  const article = document.createElement('article');
+  article.className = 'product-card';
+
+  const media = document.createElement('div');
+  media.className = 'product-card__media';
+
+  const image = document.createElement('img');
+  image.src = product.image;
+  image.alt = product.imageAlt;
+  image.loading = 'lazy';
+
+  media.appendChild(image);
+
+  const badge = document.createElement('span');
+  badge.className = 'product-card__badge';
+  badge.textContent = product.category;
+
+  const title = document.createElement('h3');
+  title.textContent = product.name;
+
+  const description = document.createElement('p');
+  description.textContent = product.description;
+
+  const tagsContainer = document.createElement('div');
+  tagsContainer.className = 'product-card__tags';
+
+  product.tags.forEach((tag) => {
+    const span = document.createElement('span');
+    span.className = 'tag';
+    span.textContent = tag;
+    tagsContainer.appendChild(span);
+  });
+
+  const footer = document.createElement('div');
+  footer.className = 'product-card__footer';
+
+  const price = document.createElement('span');
+  price.className = 'product-card__price';
+  price.textContent = product.price;
+
+  const cta = document.createElement('a');
+  cta.href = '#contacto';
+  cta.className = 'product-card__cta';
+  cta.textContent = 'Cotizar';
+
+  footer.append(price, cta);
+  article.append(media, badge, title, description, tagsContainer, footer);
+
+  return article;
+}
+
+function renderCatalog(filter = 'all') {
+  catalogGrid.innerHTML = '';
+  const filtered =
+    filter === 'all' ? products : products.filter((item) => item.category === filter);
+
+  if (!filtered.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No hay productos disponibles para esta categoría en este momento.';
+    catalogGrid.appendChild(empty);
+    return;
+  }
+
+  filtered.forEach((product) => {
+    catalogGrid.appendChild(createProductCard(product));
+  });
+}
+
+function handleFilterClick(event) {
+  const button = event.currentTarget;
+  const filter = button.dataset.filter;
+
+  filterButtons.forEach((btn) => btn.classList.remove('is-active'));
+  button.classList.add('is-active');
+
+  renderCatalog(filter);
+}
+
+filterButtons.forEach((button) => button.addEventListener('click', handleFilterClick));
+renderCatalog();
+
+newsletterForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const formData = new FormData(newsletterForm);
+  const email = (formData.get('email') || '').toString().trim();
+
+  if (!email) {
+    newsletterFeedback.textContent = 'Ingresa un correo corporativo válido para continuar.';
+    newsletterFeedback.style.color = 'var(--color-primary)';
+    return;
+  }
+
+  newsletterFeedback.textContent = '¡Gracias! Hemos registrado tu suscripción corporativa.';
+  newsletterFeedback.style.color = 'var(--color-success)';
+
+  newsletterForm.reset();
+
+  setTimeout(() => {
+    newsletterFeedback.textContent = '';
+  }, 5000);
+});
+
+contactForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const formData = new FormData(contactForm);
+  const name = formData.get('name');
+  const company = formData.get('company');
+  const segment = formData.get('segment');
+
+  if (!name || !company || !segment) {
+    contactFeedback.textContent = 'Por favor completa los campos obligatorios.';
+    contactFeedback.style.color = 'var(--color-primary)';
+    return;
+  }
+
+  contactFeedback.textContent = '¡Solicitud enviada! Nuestro equipo corporativo te contactará en breve.';
+  contactFeedback.style.color = 'var(--color-success)';
+
+  contactForm.reset();
+
+  setTimeout(() => {
+    contactFeedback.textContent = '';
+  }, 6000);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,708 @@
+:root {
+  --color-primary: #e2231a;
+  --color-primary-dark: #b81612;
+  --color-secondary: #111827;
+  --color-accent: #0f172a;
+  --color-light: #f8fafc;
+  --color-muted: #6b7280;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-success: #16a34a;
+  --shadow-soft: 0 20px 40px rgba(15, 23, 42, 0.08);
+  --shadow-card: 0 18px 30px rgba(15, 23, 42, 0.12);
+  --max-width: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Montserrat', sans-serif;
+  background: var(--color-light);
+  color: var(--color-secondary);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.topbar {
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.topbar__wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 0;
+  gap: 1rem;
+}
+
+.topbar__links {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 500;
+}
+
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.navbar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.2rem 0;
+}
+
+.navbar__brand {
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+}
+
+.navbar__logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.navbar__subtitle {
+  font-weight: 500;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+  color: var(--color-muted);
+}
+
+.navbar__menu {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  gap: 1.8rem;
+  padding: 0;
+  margin: 0;
+  font-weight: 500;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.button--primary:hover {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #fff;
+}
+
+.button--ghost:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.button--light {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.button--dark {
+  background: var(--color-secondary);
+  color: #fff;
+}
+
+.hero {
+  background: radial-gradient(circle at top left, rgba(226, 35, 26, 0.2), transparent 45%),
+              radial-gradient(circle at bottom right, rgba(15, 23, 42, 0.15), transparent 55%),
+              #0f172a;
+  color: #fff;
+  padding: 5rem 0 4rem;
+}
+
+.hero__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero__visual {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.hero__image {
+  width: min(520px, 100%);
+  border-radius: 24px;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 35px 65px rgba(8, 15, 35, 0.45);
+}
+
+.hero__copy h1 {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  margin-bottom: 1rem;
+}
+
+.hero__copy p {
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero__actions {
+  display: flex;
+  gap: 1rem;
+  margin: 2rem 0 1.5rem;
+  flex-wrap: wrap;
+}
+
+.hero__badges {
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  font-weight: 600;
+}
+
+.hero__card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+  max-width: 360px;
+  width: min(90%, 360px);
+  position: absolute;
+  bottom: -2.5rem;
+}
+
+.brand-strip {
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0.04), rgba(226, 35, 26, 0.05));
+  border-bottom: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
+}
+
+.brand-strip__wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.5rem 0;
+  flex-wrap: wrap;
+}
+
+.brand-strip__label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18rem;
+  color: var(--color-muted);
+}
+
+.brand-strip__logos {
+  display: flex;
+  gap: 2.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.brand-strip__logos img {
+  height: 28px;
+  filter: grayscale(0.1);
+  opacity: 0.9;
+}
+
+.hero__card h2 {
+  margin-top: 0;
+}
+
+.services {
+  padding: 4rem 0;
+}
+
+.services h2 {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.services__grid {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.service-card {
+  background: #fff;
+  padding: 1.8rem;
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.catalog {
+  padding: 4rem 0;
+  background: linear-gradient(180deg, #fff 0%, #f1f5f9 100%);
+}
+
+.catalog__header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.catalog__filters {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+.filter-button {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.filter-button:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.filter-button.is-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 12px 20px rgba(226, 35, 26, 0.25);
+}
+
+.catalog__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.product-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.8rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.product-card__media {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  margin: -1.8rem -1.8rem 0;
+  aspect-ratio: 4 / 3;
+  background: radial-gradient(circle at top, rgba(226, 35, 26, 0.1), transparent 65%);
+}
+
+.product-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.product-card:hover .product-card__media img {
+  transform: scale(1.05);
+}
+
+.product-card__badge {
+  position: absolute;
+  top: 1.4rem;
+  right: 1.4rem;
+  background: rgba(226, 35, 26, 0.12);
+  color: var(--color-primary);
+  font-weight: 700;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  z-index: 2;
+}
+
+.product-card h3 {
+  margin: 0 0 0.5rem;
+}
+
+.product-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.tag {
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.product-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+}
+
+.product-card__price {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.product-card__cta {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.segment {
+  padding: 4rem 0;
+}
+
+.segment--isg {
+  background: linear-gradient(135deg, #0f172a, #1f2937);
+  color: #fff;
+}
+
+.segment--idg {
+  background: #f8fafc;
+}
+
+.segment__wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.segment__wrapper--reverse {
+  direction: rtl;
+}
+
+.segment__wrapper--reverse > * {
+  direction: ltr;
+}
+
+.segment__badge {
+  justify-self: end;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 1.5rem 2rem;
+  border-radius: 16px;
+  text-align: center;
+  font-weight: 700;
+  box-shadow: var(--shadow-soft);
+}
+
+.segment--idg .segment__badge {
+  background: #fff;
+  border: 1px solid var(--color-border);
+  color: var(--color-accent);
+}
+
+.solutions {
+  padding: 4rem 0;
+}
+
+.solutions h2 {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.solutions__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.solution-card {
+  background: #fff;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  padding: 1.8rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.resources {
+  padding: 4rem 0;
+  background: linear-gradient(135deg, #ffffff 0%, #e2e8f0 100%);
+}
+
+.resources__wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+}
+
+.resources__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.resource-pill {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.resource-pill:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.newsletter-form {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.newsletter-form input {
+  flex: 1;
+  min-width: 220px;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  font-size: 1rem;
+}
+
+.newsletter-feedback {
+  margin-top: 0.75rem;
+  font-weight: 600;
+}
+
+.contact {
+  padding: 4rem 0;
+}
+
+.contact__wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.contact__highlights {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+  font-weight: 600;
+}
+
+.contact-form {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-feedback {
+  min-height: 1.2rem;
+  font-weight: 600;
+}
+
+.footer {
+  background: #0f172a;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.footer__wrapper {
+  padding: 3rem 0;
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) 2fr;
+  gap: 3rem;
+}
+
+.footer__logo {
+  font-weight: 700;
+  font-size: 1.4rem;
+}
+
+.footer__columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 2rem;
+}
+
+.footer__columns ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.footer__columns a {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.footer__legal {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1rem 0;
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.footer__legal-wrapper {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .topbar__wrapper {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .navbar__inner {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .navbar__menu {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .hero__visual {
+    order: -1;
+    position: static;
+    width: 100%;
+  }
+
+  .hero__card {
+    position: static;
+    margin-top: 1.5rem;
+    width: 100%;
+  }
+
+  .brand-strip__wrapper {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .brand-strip__label {
+    width: 100%;
+  }
+
+  .hero__actions {
+    width: 100%;
+  }
+
+  .resources__wrapper,
+  .contact__wrapper,
+  .segment__wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .segment__badge {
+    justify-self: start;
+  }
+
+  .footer__wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .footer__legal-wrapper {
+    justify-content: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated hero visual block with featured imagery and partner brand strip to reinforce Lenovo identity
- refresh catalog cards to render product photography and improve presentation while keeping filtering intact
- tweak responsive styles so imagery and color styling load reliably after deployment cache refresh

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db6d07ad008326952b416dce0345c3